### PR TITLE
Fix EditableContentPage - missing path attribute

### DIFF
--- a/src/Images/ViewModels/EditableContentPage.json.cs
+++ b/src/Images/ViewModels/EditableContentPage.json.cs
@@ -41,10 +41,7 @@ namespace Images
                 OldUrls.Add(value.OldValue);
             }
 
-            if (string.IsNullOrEmpty(value.Value))
-            {
-                Path = Helper.GetUploadDirectoryWithRoot().Replace("/","\\");
-            }
+            Path = Helper.GetUploadDirectoryWithRoot().Replace("/","\\");            
         }
     }
 }


### PR DESCRIPTION
This PR fixes the missing path issue on EditableContentPage. Each time I uploaded an image using this page, the PATH in the database was set to null. I'm not sure why it was not set every time. @un-tone could you please take a look?