### PR TITLE
Fixed PR Images#96

### DIFF
--- a/src/Images/ViewModels/EditableContentPage.json.cs
+++ b/src/Images/ViewModels/EditableContentPage.json.cs
@@ -8,6 +8,7 @@ namespace Images
     {
         protected IllustrationHelper Helper = new IllustrationHelper();
         protected List<string> OldUrls = new List<string>();
+        public string SessionId => Session.Current?.SessionId;
 
         protected override void OnData()
         {


### PR DESCRIPTION
After https://github.com/StarcounterApps/Images/pull/96 I'm getting an error when uploading an image:
![image](https://cloud.githubusercontent.com/assets/1625378/26198884/7d90d50e-3bd0-11e7-8463-e63f2c7a12a5.png)
I see that `SessionId` is used in EditableContentPage