### PR TITLE
Fix composition in Declarative Shadow DOM

### DIFF
--- a/src/Images/wwwroot/Images/viewmodels/EditableIllustrationsPage.html
+++ b/src/Images/wwwroot/Images/viewmodels/EditableIllustrationsPage.html
@@ -39,41 +39,41 @@
         <style>
             @import url("/images/css/illustrations.css");
 
-            #images-add > ::slotted(*){
+            .images-add > ::slotted(*){
                 width: 100%;
                 border: 1px solid #dddddd;
                 border-radius: 3px;
                 padding: 4px;
             }
-            #images-add > button.btn-carousel-add,
-            #images-add > ::slotted(button.btn-carousel-add) {
+            .images-add > button.btn-carousel-add,
+            .images-add > ::slotted(button.btn-carousel-add) {
                 background-image: url('/images/css/add.png');
                 background-color: #6A6A6A;
                 background-position: center;
                 background-repeat: no-repeat;
             }
             /* Duplicate ::content/::slotted rules for bug in Shadow DOM V0 Polifil */
-            #images-add > :not(slot){
+            .images-add > :not(slot){
                 width: 100%;
                 border: 1px solid #dddddd;
                 border-radius: 3px;
                 padding: 4px;
             }
-            #images-add > button.btn-carousel-add{
+            .images-add > button.btn-carousel-add{
                 background-image: url('/images/css/add.png');
                 background-color: #6A6A6A;
                 background-position: center;
                 background-repeat: no-repeat;
             }
         </style>
-        <div id="images-carousel">
-            <div id="images-thumbs">
+        <div class="images-carousel">
+            <div class="images-carousel__thumbs">
                 <slot name="images/thumbnail"></slot>
-                <div id="images-add">
+                <div class="images-add">
                     <slot name="images/add"></slot>
                 </div>
             </div>
-            <div id="images-big">
+            <div class="images-carousel__big">
                 <slot name="images/big"></slot>
             </div>
         </div>

--- a/src/Images/wwwroot/Images/viewmodels/IllustrationsPage.html
+++ b/src/Images/wwwroot/Images/viewmodels/IllustrationsPage.html
@@ -21,7 +21,7 @@
         <style>
             @import url("/images/css/illustrations.css");
         </style>
-        <div id="images-carousel">
+        <div class="images-carousel">
             <div class="images-carousel__thumbs">
                 <slot name="images/thumbnail"></slot>
             </div>


### PR DESCRIPTION
Few elements have been forgotten while upgrading CSS in PR #81. They should all use CSS classes as defined in the stylesheet, not `id` attributes.

Before:

![screen shot 2017-06-09 at 09 05 34](https://user-images.githubusercontent.com/566463/26964989-32618792-4cf4-11e7-9248-dbfcac263c1b.png)


After:
![screen shot 2017-06-09 at 09 11 17](https://user-images.githubusercontent.com/566463/26965004-3e7b574c-4cf4-11e7-9c33-16fe6865a702.png)



Tested in Chrome and Firefox