### PR TITLE
Fix resizing to the parent container on the editable illustrations page

### DIFF
--- a/src/Images/wwwroot/Images/css/illustrations.css
+++ b/src/Images/wwwroot/Images/css/illustrations.css
@@ -2,11 +2,11 @@
     display: block;
     overflow: hidden;
     display: flex;
-    height: 300px;
+    height: 400px;
+    width: 100%;
 }
 
 .images-carousel__thumbs {
-    margin: 5px;
     width: 100px;
     overflow: auto;
 }
@@ -18,7 +18,6 @@
         width: 100%;
         border: 1px solid #dddddd;
         border-radius: 3px;
-        padding: 4px;
         margin-bottom: 4px;
         cursor: pointer;
     }
@@ -28,12 +27,11 @@
         width: 100%;
         border: 1px solid #dddddd;
         border-radius: 3px;
-        padding: 4px;
         margin-bottom: 4px;
         cursor: pointer;
     }
 
 .images-carousel__big {
-    margin: 5px;
-    width: calc(100% - 100px);
+    margin-left: 5px;
+    width: 100%;
 }

--- a/src/Images/wwwroot/Images/elements/images-filedrop/images-filedrop.html
+++ b/src/Images/wwwroot/Images/elements/images-filedrop/images-filedrop.html
@@ -5,7 +5,7 @@
     <template>
         <style>
             :host {
-                display: block;
+                display: flex;
                 height: 100%;
                 position: relative;
             }
@@ -38,8 +38,6 @@
             }
 
             .img-thumbnail {
-                min-height: 50px;
-                min-width: 50px;
                 height: 100%;
                 width: 100%;
                 background-size: contain;
@@ -126,6 +124,7 @@
             }
 
             #jfFileDrop{
+                height: 100%;
                 width: 100%;
             }
         </style>

--- a/src/Images/wwwroot/Images/viewmodels/EditableIllustrationsPage.html
+++ b/src/Images/wwwroot/Images/viewmodels/EditableIllustrationsPage.html
@@ -39,41 +39,41 @@
         <style>
             @import url("/images/css/illustrations.css");
 
-            #images-add > ::slotted(*){
+            .images-add > ::slotted(*){
                 width: 100%;
                 border: 1px solid #dddddd;
                 border-radius: 3px;
                 padding: 4px;
             }
-            #images-add > button.btn-carousel-add,
-            #images-add > ::slotted(button.btn-carousel-add) {
+            .images-add > button.btn-carousel-add,
+            .images-add > ::slotted(button.btn-carousel-add) {
                 background-image: url('/images/css/add.png');
                 background-color: #6A6A6A;
                 background-position: center;
                 background-repeat: no-repeat;
             }
             /* Duplicate ::content/::slotted rules for bug in Shadow DOM V0 Polifil */
-            #images-add > :not(slot){
+            .images-add > :not(slot){
                 width: 100%;
                 border: 1px solid #dddddd;
                 border-radius: 3px;
                 padding: 4px;
             }
-            #images-add > button.btn-carousel-add{
+            .images-add > button.btn-carousel-add{
                 background-image: url('/images/css/add.png');
                 background-color: #6A6A6A;
                 background-position: center;
                 background-repeat: no-repeat;
             }
         </style>
-        <div id="images-carousel">
-            <div id="images-thumbs">
+        <div class="images-carousel">
+            <div class="images-carousel__thumbs">
                 <slot name="images/thumbnail"></slot>
-                <div id="images-add">
+                <div class="images-add">
                     <slot name="images/add"></slot>
                 </div>
             </div>
-            <div id="images-big">
+            <div class="images-carousel__big">
                 <slot name="images/big"></slot>
             </div>
         </div>

--- a/src/Images/wwwroot/Images/viewmodels/IllustrationsPage.html
+++ b/src/Images/wwwroot/Images/viewmodels/IllustrationsPage.html
@@ -21,7 +21,7 @@
         <style>
             @import url("/images/css/illustrations.css");
         </style>
-        <div id="images-carousel">
+        <div class="images-carousel">
             <div class="images-carousel__thumbs">
                 <slot name="images/thumbnail"></slot>
             </div>


### PR DESCRIPTION
Based on PR #100

Fix the dimensions of the carousel big image, which was not adapting correctly to the size of the container when editing.

With this fix:

![2017-06-09 14_58_06-people](https://user-images.githubusercontent.com/566463/26976468-335163ea-4d24-11e7-8181-da38ecaa9bc8.png)

Without:

![2017-06-09 14_58_42-people](https://user-images.githubusercontent.com/566463/26976464-2f5c76d0-4d24-11e7-93f6-de7506e53b05.png)

