### PR TITLE
Pass along parameters to star (run.bat)

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -2,4 +2,4 @@
 
 IF "%CONFIGURATION%"=="" SET CONFIGURATION=Debug
 
-star --resourcedir="%~dp0src\Images\wwwroot" "%~dp0src/Images/bin/%CONFIGURATION%/Images.exe"
+star %* --resourcedir="%~dp0src\Images\wwwroot" "%~dp0src/Images/bin/%CONFIGURATION%/Images.exe"


### PR DESCRIPTION
Pass along parameters to star (run.bat); for Starcounter/Guidelines#31 .