### PR TITLE
Fix for error when switching images

### DIFF
--- a/src/Images/wwwroot/Images/viewmodels/EditableIllustrationsPage.html
+++ b/src/Images/wwwroot/Images/viewmodels/EditableIllustrationsPage.html
@@ -23,7 +23,8 @@
             var template = script.previousElementSibling;
 
             template.onPreviewClick = function (e) {
-                template.set("model.item.Select$", ++template.get("model.item.Select$"));
+                var model = e.model;
+                model.set("item.Select$", ++model.item.Select$);
             };
 
             template.onStateChange = function (ev) {

--- a/src/Images/wwwroot/Images/viewmodels/IllustrationsPage.html
+++ b/src/Images/wwwroot/Images/viewmodels/IllustrationsPage.html
@@ -13,7 +13,8 @@
             var template = script.previousElementSibling;
             
             template.onPreviewClick = function (e) {
-                template.set("model.item.Select$", ++template.get("model.item.Select$"));
+                var model = e.model;
+                model.set("item.Select$", ++model.item.Select$);
             };
         })();
     </script>


### PR DESCRIPTION
Previous version would throw an error because the desired item can't be access in that way; for Issue #104 .
